### PR TITLE
Improving logic for serving a single recommendation

### DIFF
--- a/ers_evaluation/templates/ers_evaluation/evaluation.html
+++ b/ers_evaluation/templates/ers_evaluation/evaluation.html
@@ -1,4 +1,4 @@
-{%load static%}
+{% load static %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -15,7 +15,7 @@
     <form method="post">
         {% csrf_token %}
         <ul>
-            {% for recommendation in recommendations %}
+            {% if recommendation %}
                 <li>
                     <b>Case {{ evaluation_number }}:</b><br><br>
                     <b>Recommendation:</b> {{ recommendation.recommendation_text }}<br>
@@ -35,11 +35,12 @@
                     <label for="comment_{{ recommendation.id }}">Comment:</label>
                     <textarea id="comment_{{ recommendation.id }}" name="comment_{{ recommendation.id }}" rows="3" cols="40"></textarea>
                 </li>
-            {% empty %}
+            {% else %}
                 <li>No recommendations available.</li>
-            {% endfor %}
+            {% endif %}
         </ul>
         <input type="hidden" name="user_id" value="{{ user_id }}">
+        <input type="hidden" name="recommendation_id" value="{{ recommendation.id }}">
         <button type="submit" class="btn" style="float: right; margin-right: 10px">Next</button>
         <button type="button" class="btn" style="float: right" onclick="location.href='{% url 'index' %}'">Cancel</button>
     </form>

--- a/ers_evaluation/views.py
+++ b/ers_evaluation/views.py
@@ -27,29 +27,30 @@ def evaluation(request):
     # Filter out recommendations that the user has already evaluated
     completed_evaluations_recommendation_id = [evaluation.recommendation.id for evaluation in completed_evaluations]
     unevaluated_recommendations = recommendations.exclude(id__in=completed_evaluations_recommendation_id)
-    selected_texts = random.sample(list(unevaluated_recommendations), 1)  # Chooses 2 random recommendations
+    selected_text = random.choice(unevaluated_recommendations)
     
     context = {
         "evaluation_number": completed_evaluations.count() + 1,
-        "recommendations": selected_texts,
+        "recommendation": selected_text,
         "user_id": request.user.id
     }
     
     # When save/next button gets pressed
     if request.method == "POST":
         user_id = request.POST.get("user_id")
+        recommendation_id = int(request.POST.get("recommendation_id"))
+        recommendation = recommendations.filter(id=recommendation_id).first()
+
+        rating = request.POST.get(f"rating_{recommendation.id}")
+        comment = request.POST.get(f"comment_{recommendation.id}")
         
-        for recommendation in recommendations:
-            rating = request.POST.get(f"rating_{recommendation.id}")
-            comment = request.POST.get(f"comment_{recommendation.id}")
-            
-            if rating:
-                Evaluation.objects.create(
-                    recommendation=recommendation,
-                    user_id=user_id,
-                    rating=rating,
-                    comment=comment if comment else ""
-                )
+        Evaluation.objects.create(
+            recommendation=recommendation,
+            user_id=user_id,
+            rating=rating,
+            comment=comment if comment else ""
+        )
+
         return redirect('evaluation')
     
     return render(request, 'ers_evaluation/evaluation.html', context)


### PR DESCRIPTION
In this PR I improved the logic which was before better for multiple recommendations per site. Since we will only have one per site, I removed for loops which were redundant.

Note:
1) 
"recommendation = recommendations.filter(id=recommendation_id).first()" 
above line absolutely needs .first() in the end as it would otherwise return a queryset instead of an object
2)
I was able to remove "if rating" because we are not in a for loop anymore and because there is always a default rating of 4